### PR TITLE
Fixed multi-paragraph enumerated lists

### DIFF
--- a/_posts/2015-07-31-pagerank.md
+++ b/_posts/2015-07-31-pagerank.md
@@ -369,28 +369,24 @@ To finish up, let's recap what we've learned.
 
  1. **Computers are surprisingly fast!**
 
- Modern hardware can do quite a lot of work in a short time &ndash; for example, it can iterate over 3 billion edges and exchange hundreds of millions of updates in less than a second. However, to get this performance, it is necessarily to carefully think about how every layer of the system works. Our ability to speed up PageRank by up to 16x (or 23x, with the new numbers) suggests that there's still a fair bit of this kind of optimization to be had in distributed data processing systems.
+    Modern hardware can do quite a lot of work in a short time &ndash; for example, it can iterate over 3 billion edges and exchange hundreds of millions of updates in less than a second. However, to get this performance, it is necessarily to carefully think about how every layer of the system works. Our ability to speed up PageRank by up to 16x (or 23x, with the new numbers) suggests that there's still a fair bit of this kind of optimization to be had in distributed data processing systems.
 
  2. **Faster networks *can* help, and they influence implementations.**
 
- Strategies that are helpful on a (slow) 1G network, such as process-level aggregation, can actually be _harmful_ on a faster 10G network.
+    Strategies that are helpful on a (slow) 1G network, such as process-level aggregation, can actually be _harmful_ on a faster 10G network.
  Spark and GraphX are examples of systems designed with the assumption that I/O is slow, and that doing extra computing to reduce the I/O required is always beneficial. As we've shown with the aggregation strategies, this is not necessarily the case. This motivates thinking about whether we need systems capable of dynamically adapting their strategies to the hardware they're running on.
 
  3. **Distributed processing _does_ help even communication-heavy graph workloads.**
 
- Our best distributed PageRank is 11x faster than even the smart, Hilbert-curve-based single-threaded implementation (now 13.4x), and 5x faster than our best multi-threaded, single machine implementation. In other words, even communication-heavy workloads on data sets that fit into a single machine can get significant benefit from a distributed implementation, provided it makes good use of available system resources.
+    Our best distributed PageRank is 11x faster than even the smart, Hilbert-curve-based single-threaded implementation (now 13.4x), and 5x faster than our best multi-threaded, single machine implementation. In other words, even communication-heavy workloads on data sets that fit into a single machine can get significant benefit from a distributed implementation, provided it makes good use of available system resources.
 
  4. **Balanced system design is key.**
 
- Our implementation overlaps communication and computation, stressing CPU and network resources roughly equally. In general, when adding to one resource failed to deliver speedups, we could realize them by improving on another: when we found that network utilization was uneven, we improved it by re-structuring the computation to overlap communication more, and when computation became a bottleneck, we reduced it by communicating more data. The goal should be a system in which improving any single resource won't yield a speedup on its own. Spark/GraphX, by comparison, looks highly CPU-bound, and needs some heavy optimization before becoming network-bound.
+    Our implementation overlaps communication and computation, stressing CPU and network resources roughly equally. In general, when adding to one resource failed to deliver speedups, we could realize them by improving on another: when we found that network utilization was uneven, we improved it by re-structuring the computation to overlap communication more, and when computation became a bottleneck, we reduced it by communicating more data. The goal should be a system in which improving any single resource won't yield a speedup on its own. Spark/GraphX, by comparison, looks highly CPU-bound, and needs some heavy optimization before becoming network-bound.
 
  5. **Timely dataflow is quite a neat paradigm.**
 
- A lot of our freedom to optimize things is owed to the flexibility of timely dataflow, which only mandates some very light progress tracking, and that workers respect the promise to send no more data for a timestamp after it has been "notified". Since this paradigm does not mandate many _implementation choices_, we are able to implement things such that all system resources are best utilized at all times.
-
- 6. **Markdown is pretty shit at getting enumerated lists right, even when I supply the numbers.**
-
- That one is a bonus lesson learned.
+    A lot of our freedom to optimize things is owed to the flexibility of timely dataflow, which only mandates some very light progress tracking, and that workers respect the promise to send no more data for a timestamp after it has been "notified". Since this paradigm does not mandate many _implementation choices_, we are able to implement things such that all system resources are best utilized at all times.
 
 While our timely dataflow implementation surely isn't the last word in graph processing, it really is pretty simple, it gets the job done, and it goes pretty fast. You could certainly improve many of the implementation choices we made, or do something totally new, different and better! It really isn't that hard to write this stuff, and we'd love to see more people doing inventive work rather than doing minor tweaks to existing monolithic stacks.
 


### PR DESCRIPTION
Changelog: 
1. Multi-paragraph enumerated lists work if you indent each paragraph with a tab or 4 spaces.
2. Removed enumerated list item #6.
